### PR TITLE
Image Questions

### DIFF
--- a/questionservice/src/models/question-model.ts
+++ b/questionservice/src/models/question-model.ts
@@ -229,7 +229,7 @@ const generateSampleTest = () => {
       query: `SELECT ?templateLabel ?answerLabel
       WHERE {
         ?answer wdt:P31 wd:Q5;  # Instance of human
-                wdt:P106 wd:Q937857;  # Occupation: "footbal player"
+                wdt:P106 wd:Q937857;  # Occupation: "inventor"
                 wdt:P18 ?template;
         SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
       }

--- a/questionservice/src/models/question-model.ts
+++ b/questionservice/src/models/question-model.ts
@@ -129,28 +129,6 @@ const generateSampleTest = () => {
 
   aQuestion.save();
 
-  // Who wrote...?
-  //   aQuestion = new QuestionModel({
-  //     questionTemplate: 'Who wrote $$$?',
-  //     question_type: {
-  //       name: 'Books',
-  //       query: `SELECT ?templateLabel ?answerLabel
-  //         WHERE {
-  //           ?answer wdt:P31 wd:Q5;  # Ensure the entity is a human
-  //                   wdt:P27 wd:Q174193;
-  //                   wdt:P106 wd:Q36180;  # Ensure the occupation is writer
-  //                   wdt:P800 ?template.  # Retrieve the books written by the writer
-  //           SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es". }
-  //         }
-  //         ORDER BY UUID()
-  //         LIMIT 5
-  //         `,
-  //       entities: [],
-  //     },
-  //   });
-
-  //   aQuestion.save();
-
   // Chemical symbol of an element
   // We make a first query searching for any element in the periodic table
   // Then we search for elements with similar associated symbols instead of selecting at random
@@ -196,60 +174,72 @@ const generateSampleTest = () => {
   });
   aQuestion.save();
 
-  // Raúl
-  // With this query I can consistently get several tourists attractions/famous places from a country.
-  // There are a few things to consider:
-  // Some entities may not have an associated label, making it so what is returned is not a name but an
-  // entity in format QXXXXXX. If this happens we will probably need to cancel the creation of the question.
-  // We could try to obtain more attractions, but the time to perform the query becomes unfeasible.
-  // I could also make it so that several countries are considered. However, it becomes much less consistent.
-  // Also, there are countries which do not return any attractions.
-  // If we want to generate the question, in this case one query will not be enough.
-  // We need to decide what to do:
-  // We can do more simple things for now, since this is just the first prototype.
-  // We can try to modify the Question Model or find a new way to approach the problem to try manage this type of cases.
-  // We could also forget this specific question and go on, but we will probably encounter similar problems
-  // in the future.
-  // IMPORTANT: Probably there is a better approach for the query below, but with mi current knowledge of
-  // the Wikidata Query Service, I don't know which it's.
+  // Image Question templates
 
-  // aQuestion = new QuestionModel({
-  //   questionTemplate: "What is a famous place from Peru?",
-  //   question_type: {
-  //     name: "Landmarks",
-  //     query: `SELECT ?templateLabel ?answerLabel
-  //             WHERE {
+  // Flag of a country, autonomous community of Spain or USA state
+  aQuestion = new QuestionModel({
+    questionTemplate: 'This flag is from...?',
+    question_type: {
+      name: 'Images_Flags',
+      query: `SELECT ?templateLabel ?answerLabel
+      WHERE {
+        ?answer wdt:P31 wd:$$$; # Entity
+                wdt:P41 ?template.  # Capital
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en"}
+      }
+      ORDER BY UUID() # Add randomness to the results
+      LIMIT 5
+      `,
+      entities: [
+        'Q6256', // Country (any)
+        'Q10742', // Autonomous Community of Spain
+        'Q35657' // State of the United States],
+      ]
+    },
+  });
+  aQuestion.save();
 
-  //               ?template wdt:P31/wdt:P279* wd:Q4989906;
-  //               wdt:P17  ?answer.
 
-  //               SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}.
+  // Guess the person by an image
+  // In this case physiscists
+  aQuestion = new QuestionModel({
+    questionTemplate: 'Who is this physiscist?',
+    question_type: {
+      name: 'Images_Physics',
+      query: `SELECT ?templateLabel ?answerLabel
+      WHERE {
+        ?answer wdt:P31 wd:Q5;  # Instance of human
+                wdt:P106 wd:Q169470;  # Occupation: "physicist"
+                wdt:P18 ?template;
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+      LIMIT 5    
+      `,
+      entities: []
+    },
+  });
+  aQuestion.save();
 
-  //               {
-  //                 SELECT ?answer
-  //                 WHERE {
-  //                   ?answer wdt:P31 wd:Q6256; # Entity
-  //                 }
-  //                 ORDER BY UUID()
-  //                 LIMIT 1
-  //               }
-  //             }
-  //             ORDER BY UUID() # Add randomness to the results
-  //             LIMIT 2`
-  //   }
-  // });
+  // Guess the person by an image
+  // In this case inventors
+  aQuestion = new QuestionModel({
+    questionTemplate: 'Who is this inventor?',
+    question_type: {
+      name: 'Images_Inventor',
+      query: `SELECT ?templateLabel ?answerLabel
+      WHERE {
+        ?answer wdt:P31 wd:Q5;  # Instance of human
+                wdt:P106 wd:Q937857;  # Occupation: "footbal player"
+                wdt:P18 ?template;
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+      LIMIT 5  
+      `,
+      entities: []
+    },
+  });
+  aQuestion.save();
 
-  // aQuestion.save()
-
-  // aQuestion = new QuestionModel({
-  //   questionTemplate: "What is the typical dish of Peru?",
-  //   question_type: {
-  //     name: "Gastronomy",
-  //     query: "DELETE ALL"
-  //   }
-  // });
-
-  // aQuestion.save()
 };
 
 export { QuestionModel, generateSampleTest };

--- a/questionservice/src/services/question-generator.ts
+++ b/questionservice/src/services/question-generator.ts
@@ -4,6 +4,9 @@ import { getWikidataSparql } from '@entitree/helper';
 const distractorsNumber: number = 3;
 const optionsNumber: number = distractorsNumber + 1;
 
+/**
+ * Interface for a question which may or not contain an image
+ */
 interface Question {
   id: number,
   question: string,
@@ -80,6 +83,7 @@ function getRandomItem<T>(array: T[]): T {
  * @param templateNumber number of the template
  * @param questionGen  Question generated
  * @param answersArray  Array of answers
+ * @param image  Image URL which is optional
  * @returns the JSON question
  */
 const questionJsonBuilder = (
@@ -128,6 +132,7 @@ const generateQuestionJson = async (
       wikidataResponse[randomIndexes[0]].templateLabel
     );
 
+    // Check if the question is an image question
     let image = "";
     if (questionTemplate.question_type.name.includes('Image')) {
       image = wikidataResponse[randomIndexes[0]].templateLabel;
@@ -137,7 +142,6 @@ const generateQuestionJson = async (
     var answersArray: object[] = getRandomResponses(wikidataResponse, randomIndexes);
 
     // Build it
-
     return questionJsonBuilder(templateNumber, questionGen, answersArray, image);
   } catch (error) {
     console.error(error);

--- a/questionservice/src/services/question-generator.ts
+++ b/questionservice/src/services/question-generator.ts
@@ -98,6 +98,7 @@ const questionJsonBuilder = (
     answers: answersArray,
     correctAnswerId: 1,
   };
+
   if (image != "") {
     myJson.image = image;
   }
@@ -133,8 +134,8 @@ const generateQuestionJson = async (
     );
 
     // Check if the question is an image question
-    let image = "";
-    if (questionTemplate.question_type.name.includes('Image')) {
+    let image = null;
+    if (questionTemplate.question_type.name.includes('Images')) {
       image = wikidataResponse[randomIndexes[0]].templateLabel;
     }
 
@@ -142,7 +143,10 @@ const generateQuestionJson = async (
     var answersArray: object[] = getRandomResponses(wikidataResponse, randomIndexes);
 
     // Build it
-    return questionJsonBuilder(templateNumber, questionGen, answersArray, image);
+    if (image != null)
+      return questionJsonBuilder(templateNumber, questionGen, answersArray, image);
+    else
+      return questionJsonBuilder(templateNumber, questionGen, answersArray);
   } catch (error) {
     console.error(error);
     console.error('Error while fetching Wikidata');

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -13,48 +13,6 @@ jest.mock("../src/models/question-model")
 jest.mock("@entitree/helper")
 
 const numberQuestions = 1
-
-async function mockQuestionGeneration() {
-    // Mock response for fetching MongoDB documents
-    const mockResponseAggregate: object[] = [{
-        questionTemplate: 'What is the Capital of $$$ ?',
-        question_type: {
-            name: 'Capitals',
-            query: `SELECT ?templateLabel ?answerLabel
-                    WHERE {
-                    ?template wdt:P31 wd:$$$; # Entity
-                    wdt:P36 ?answer.  # Capital
-                    SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
-                    }
-                    ORDER BY UUID() # Add randomness to the results
-                    LIMIT 10`,
-            entities: [
-                'Q6256',
-                'Q10742',
-            ],
-        }
-    }];
-    (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
-
-    // Mock response for Wikidata call
-    const mockResponseWikidata = [{
-        templateLabel: "Peru",
-        answerLabel: "Lima"
-    }, {
-        templateLabel: "Spain",
-        answerLabel: "Madrid"
-    }, {
-        templateLabel: "Russia",
-        answerLabel: "Moscow"
-    }, {
-        templateLabel: "Ucrania",
-        answerLabel: "Kiev"
-    }];
-    (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
-
-    const response = await generateQuestions(numberQuestions) as any
-    return response;
-}
 describe("Question Service - Question Generator", () => {
 
     beforeEach(() => {
@@ -146,6 +104,52 @@ function checkCalltoQuestionModelAggregate() {
     ]);
 }
 
+async function mockWikidataResponse(mockResponseWikidata: any) {
+    (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+
+    const response = await generateQuestions(numberQuestions) as any
+    return response;
+}
+
+async function mockQuestionGeneration() {
+    // Mock response for fetching MongoDB documents
+    const mockResponseAggregate: object[] = [{
+        questionTemplate: 'What is the Capital of $$$ ?',
+        question_type: {
+            name: 'Capitals',
+            query: `SELECT ?templateLabel ?answerLabel
+                    WHERE {
+                    ?template wdt:P31 wd:$$$; # Entity
+                    wdt:P36 ?answer.  # Capital
+                    SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
+                    }
+                    ORDER BY UUID() # Add randomness to the results
+                    LIMIT 10`,
+            entities: [
+                'Q6256',
+                'Q10742',
+            ],
+        }
+    }];
+    (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+
+    // Mock response for Wikidata call
+    const mockResponseWikidata = [{
+        templateLabel: "Peru",
+        answerLabel: "Lima"
+    }, {
+        templateLabel: "Spain",
+        answerLabel: "Madrid"
+    }, {
+        templateLabel: "Russia",
+        answerLabel: "Moscow"
+    }, {
+        templateLabel: "Ucrania",
+        answerLabel: "Kiev"
+    }];
+    return await mockWikidataResponse(mockResponseWikidata);
+}
+
 async function mockQuestionGenerationWithImage() {
     // Mock response for fetching MongoDB documents
     const mockResponseAggregate: object[] = [{
@@ -184,11 +188,7 @@ async function mockQuestionGenerationWithImage() {
         templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
         answerLabel: "Slovak Republic"
     }];
-    (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
-
-    const response = await generateQuestions(numberQuestions) as any
-    return response;
-
+    return await mockWikidataResponse(mockResponseWikidata);
 }
 
 function checkAllFields(response: any) {

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -14,7 +14,7 @@ jest.mock("@entitree/helper")
 
 describe("Question Service - Question Generator", () => {
 
-    beforeEach( () =>{
+    beforeEach(() => {
         jest.clearAllMocks()
     })
 
@@ -36,24 +36,24 @@ describe("Question Service - Question Generator", () => {
                         ORDER BY UUID() # Add randomness to the results
                         LIMIT 10`,
                 entities: [
-                    'Q6256', 
+                    'Q6256',
                     'Q10742',
                 ],
             }
-        }]; 
+        }];
         (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
 
         // Mock response for Wikidata call
         const mockResponseWikidata = [{
             templateLabel: "Peru",
             answerLabel: "Lima"
-        },{
+        }, {
             templateLabel: "Spain",
             answerLabel: "Madrid"
-        },{
+        }, {
             templateLabel: "Russia",
             answerLabel: "Moscow"
-        },{
+        }, {
             templateLabel: "Ucrania",
             answerLabel: "Kiev"
         }];
@@ -63,7 +63,7 @@ describe("Question Service - Question Generator", () => {
 
         expect(QuestionModel.aggregate).toHaveBeenCalledWith([
             { $sample: { size: numberQuestions } },
-          ]);
+        ]);
         expect(response.length).toBe(numberQuestions)
     })
 
@@ -83,24 +83,24 @@ describe("Question Service - Question Generator", () => {
                         ORDER BY UUID() # Add randomness to the results
                         LIMIT 10`,
                 entities: [
-                    'Q6256', 
+                    'Q6256',
                     'Q10742',
                 ],
             }
-        }]; 
+        }];
         (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
 
         // Mock response for Wikidata call
         const mockResponseWikidata = [{
             templateLabel: "Peru",
             answerLabel: "Lima"
-        },{
+        }, {
             templateLabel: "Spain",
             answerLabel: "Madrid"
-        },{
+        }, {
             templateLabel: "Russia",
             answerLabel: "Moscow"
-        },{
+        }, {
             templateLabel: "Ucrania",
             answerLabel: "Kiev"
         }];
@@ -110,7 +110,7 @@ describe("Question Service - Question Generator", () => {
 
         expect(QuestionModel.aggregate).toHaveBeenCalledWith([
             { $sample: { size: numberQuestions } },
-          ]);
+        ]);
 
         expect(response[0]).toHaveProperty("id") // a given id
         expect(response[0]).toHaveProperty("question") // the generated question
@@ -119,7 +119,7 @@ describe("Question Service - Question Generator", () => {
         expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
     })
 
-    
+
     it("should return an error if fetching documents from Mongo fails", async () => {
 
         // Mock response for fetching MongoDB documents
@@ -127,11 +127,11 @@ describe("Question Service - Question Generator", () => {
         (QuestionModel.aggregate as jest.Mock).mockRejectedValue(rejectedMongoResponse);
 
         // Expect that aggregate function rejected with the rejectedMongoResponse
-        await expect( generateQuestions(numberQuestions) ).rejects.toThrow("Mock - Error fetching Questions");
-        
+        await expect(generateQuestions(numberQuestions)).rejects.toThrow("Mock - Error fetching Questions");
+
     })
 
-    
+
     it("should return an error if calling wikidata fails", async () => {
 
         // Mock response for fetching MongoDB documents
@@ -148,11 +148,11 @@ describe("Question Service - Question Generator", () => {
                         ORDER BY UUID() # Add randomness to the results
                         LIMIT 10`,
                 entities: [
-                    'Q6256', 
+                    'Q6256',
                     'Q10742',
                 ],
             }
-        }]; 
+        }];
         (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
 
         // Mock response for Wikidata call
@@ -160,11 +160,119 @@ describe("Question Service - Question Generator", () => {
         (getWikidataSparql as jest.Mock).mockRejectedValue(rejectedWikidataResponse)
 
         // Expect that Wikidata call function rejected with the rejectedWikidataResponse
-        await expect( generateQuestions(numberQuestions) ).rejects.toThrow("Mock - Error from Wikidata");
-        
- 
+        await expect(generateQuestions(numberQuestions)).rejects.toThrow("Mock - Error from Wikidata");
+
+
     })
-    
+
+    it("should return 1 image question with all correct parameters when generator succeeds", async () => {
+
+        // Mock response for fetching MongoDB documents
+        const mockResponseAggregate: object[] = [{
+            questionTemplate: 'This flag is from...?',
+            question_type: {
+                name: 'Images_Flags',
+                query: `SELECT ?templateLabel ?answerLabel
+              WHERE {
+                ?answer wdt:P31 wd:$$$; # Entity
+                        wdt:P41 ?template.  # Capital
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "en"}
+              }
+              ORDER BY UUID() # Add randomness to the results
+              LIMIT 5
+              `,
+                entities: [
+                    'Q6256', // Country (any)
+                    'Q10742', // Autonomous Community of Spain
+                    'Q35657' // State of the United States],
+                ]
+            },
+        }];
+        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+
+        // Mock response for Wikidata call
+        const mockResponseWikidata = [{
+            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Lesotho.svg",
+            answerLabel: "Lesotho"
+        }, {
+            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Senegal.svg",
+            answerLabel: "Senegal"
+        }, {
+            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Zambia.svg",
+            answerLabel: "Zambia"
+        }, {
+            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
+            answerLabel: "Slovak Republic"
+        }];
+        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+
+        const response = await generateQuestions(numberQuestions) as any
+
+        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
+            { $sample: { size: numberQuestions } },
+        ]);
+
+        expect(response[0]).toHaveProperty("id") // a given id
+        expect(response[0]).toHaveProperty("question") // the generated question
+        expect(response[0]).toHaveProperty("answers") // a list of answers
+        expect(response[0]).toHaveProperty("image") // an image field
+        expect(response[0].answers.length).toBe(4) // 4 answers
+        expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+    })
+
+    it("should return 1 question with all correct parameters and no image field when not needed", async () => {
+
+        // Mock response for fetching MongoDB documents
+        const mockResponseAggregate: object[] = [{
+            questionTemplate: 'What is the Capital of $$$ ?',
+            question_type: {
+                name: 'Capitals',
+                query: `SELECT ?templateLabel ?answerLabel
+                        WHERE {
+                        ?template wdt:P31 wd:$$$; # Entity
+                        wdt:P36 ?answer.  # Capital
+                        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
+                        }
+                        ORDER BY UUID() # Add randomness to the results
+                        LIMIT 10`,
+                entities: [
+                    'Q6256',
+                    'Q10742',
+                ],
+            }
+        }];
+        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+
+        // Mock response for Wikidata call
+        const mockResponseWikidata = [{
+            templateLabel: "Peru",
+            answerLabel: "Lima"
+        }, {
+            templateLabel: "Spain",
+            answerLabel: "Madrid"
+        }, {
+            templateLabel: "Russia",
+            answerLabel: "Moscow"
+        }, {
+            templateLabel: "Ucrania",
+            answerLabel: "Kiev"
+        }];
+        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+
+        const response = await generateQuestions(numberQuestions) as any
+
+        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
+            { $sample: { size: numberQuestions } },
+        ]);
+
+        expect(response[0]).toHaveProperty("id") // a given id
+        expect(response[0]).toHaveProperty("question") // the generated question
+        expect(response[0]).toHaveProperty("answers") // a list of answers
+        expect(response[0].answers.length).toBe(4) // 4 answers
+        expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+        expect(response[0]).not.toHaveProperty("image") // no image field
+    })
+
 
 
 

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -192,16 +192,16 @@ describe("Question Service - Question Generator", () => {
 
         // Mock response for Wikidata call
         const mockResponseWikidata = [{
-            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Lesotho.svg",
+            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Lesotho.svg",
             answerLabel: "Lesotho"
         }, {
-            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Senegal.svg",
+            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Senegal.svg",
             answerLabel: "Senegal"
         }, {
-            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Zambia.svg",
+            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Zambia.svg",
             answerLabel: "Zambia"
         }, {
-            templateLabel: "http://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
+            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
             answerLabel: "Slovak Republic"
         }];
         (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -24,38 +24,37 @@ describe("Question Service - Question Generator", () => {
 
         // Mock response for fetching MongoDB documents
         const mockResponseAggregate: object[] = [{
-            questionTemplate: 'What is the Capital of $$$ ?',
+            questionTemplate: 'What is the the atomic number of $$$?',
             question_type: {
-                name: 'Capitals',
+                name: 'Chemistry',
                 query: `SELECT ?templateLabel ?answerLabel
-                        WHERE {
-                        ?template wdt:P31 wd:$$$; # Entity
-                        wdt:P36 ?answer.  # Capital
-                        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
-                        }
-                        ORDER BY UUID() # Add randomness to the results
-                        LIMIT 10`,
-                entities: [
-                    'Q6256',
-                    'Q10742',
-                ],
-            }
+              WHERE
+              {
+                ?template wdt:P31 wd:Q11344;
+                         wdt:P1086 ?answer;
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+              }
+              ORDER BY UUID()
+              LIMIT 10
+              `,
+                entities: [],
+            },
         }];
         (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
 
         // Mock response for Wikidata call
         const mockResponseWikidata = [{
-            templateLabel: "Peru",
-            answerLabel: "Lima"
+            templateLabel: "Hydrogen",
+            answerLabel: "1"
         }, {
-            templateLabel: "Spain",
-            answerLabel: "Madrid"
+            templateLabel: "Cooper",
+            answerLabel: "29"
         }, {
-            templateLabel: "Russia",
-            answerLabel: "Moscow"
+            templateLabel: "Magnesium",
+            answerLabel: "12"
         }, {
-            templateLabel: "Ucrania",
-            answerLabel: "Kiev"
+            templateLabel: "Heliun",
+            answerLabel: "2"
         }];
         (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
 

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -12,112 +12,70 @@ jest.mock("../src/models/question-model")
 // Avoiding flakiness of API calls
 jest.mock("@entitree/helper")
 
+const numberQuestions = 1
+
+async function mockQuestionGeneration() {
+    // Mock response for fetching MongoDB documents
+    const mockResponseAggregate: object[] = [{
+        questionTemplate: 'What is the Capital of $$$ ?',
+        question_type: {
+            name: 'Capitals',
+            query: `SELECT ?templateLabel ?answerLabel
+                    WHERE {
+                    ?template wdt:P31 wd:$$$; # Entity
+                    wdt:P36 ?answer.  # Capital
+                    SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
+                    }
+                    ORDER BY UUID() # Add randomness to the results
+                    LIMIT 10`,
+            entities: [
+                'Q6256',
+                'Q10742',
+            ],
+        }
+    }];
+    (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+
+    // Mock response for Wikidata call
+    const mockResponseWikidata = [{
+        templateLabel: "Peru",
+        answerLabel: "Lima"
+    }, {
+        templateLabel: "Spain",
+        answerLabel: "Madrid"
+    }, {
+        templateLabel: "Russia",
+        answerLabel: "Moscow"
+    }, {
+        templateLabel: "Ucrania",
+        answerLabel: "Kiev"
+    }];
+    (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+
+    const response = await generateQuestions(numberQuestions) as any
+    return response;
+}
 describe("Question Service - Question Generator", () => {
 
     beforeEach(() => {
         jest.clearAllMocks()
     })
-
-    const numberQuestions = 1
-
     it("should return 1 question when generator succeeds", async () => {
 
-        // Mock response for fetching MongoDB documents
-        const mockResponseAggregate: object[] = [{
-            questionTemplate: 'What is the the atomic number of $$$?',
-            question_type: {
-                name: 'Chemistry',
-                query: `SELECT ?templateLabel ?answerLabel
-              WHERE
-              {
-                ?template wdt:P31 wd:Q11344;
-                         wdt:P1086 ?answer;
-                SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-              }
-              ORDER BY UUID()
-              LIMIT 10
-              `,
-                entities: [],
-            },
-        }];
-        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+        const response = await mockQuestionGeneration();
 
-        // Mock response for Wikidata call
-        const mockResponseWikidata = [{
-            templateLabel: "Hydrogen",
-            answerLabel: "1"
-        }, {
-            templateLabel: "Cooper",
-            answerLabel: "29"
-        }, {
-            templateLabel: "Magnesium",
-            answerLabel: "12"
-        }, {
-            templateLabel: "Heliun",
-            answerLabel: "2"
-        }];
-        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
-
-        const response = await generateQuestions(numberQuestions) as object[]
-
-        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
-            { $sample: { size: numberQuestions } },
-        ]);
+        checkCalltoQuestionModelAggregate();
         expect(response.length).toBe(numberQuestions)
     })
 
     it("should return 1 question with all correct parameters when generator succeeds", async () => {
 
-        // Mock response for fetching MongoDB documents
-        const mockResponseAggregate: object[] = [{
-            questionTemplate: 'What is the Capital of $$$ ?',
-            question_type: {
-                name: 'Capitals',
-                query: `SELECT ?templateLabel ?answerLabel
-                        WHERE {
-                        ?template wdt:P31 wd:$$$; # Entity
-                        wdt:P36 ?answer.  # Capital
-                        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
-                        }
-                        ORDER BY UUID() # Add randomness to the results
-                        LIMIT 10`,
-                entities: [
-                    'Q6256',
-                    'Q10742',
-                ],
-            }
-        }];
-        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+        const response = await mockQuestionGeneration();
 
-        // Mock response for Wikidata call
-        const mockResponseWikidata = [{
-            templateLabel: "Peru",
-            answerLabel: "Lima"
-        }, {
-            templateLabel: "Spain",
-            answerLabel: "Madrid"
-        }, {
-            templateLabel: "Russia",
-            answerLabel: "Moscow"
-        }, {
-            templateLabel: "Ucrania",
-            answerLabel: "Kiev"
-        }];
-        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+        checkCalltoQuestionModelAggregate();
 
-        const response = await generateQuestions(numberQuestions) as any
-
-        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
-            { $sample: { size: numberQuestions } },
-        ]);
-
-        expect(response[0]).toHaveProperty("id") // a given id
-        expect(response[0]).toHaveProperty("question") // the generated question
-        expect(response[0]).toHaveProperty("answers") // a list of answers
-        expect(response[0].answers.length).toBe(4) // 4 answers
-        expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+        checkAllFields(response);
     })
-
 
     it("should return an error if fetching documents from Mongo fails", async () => {
 
@@ -129,7 +87,6 @@ describe("Question Service - Question Generator", () => {
         await expect(generateQuestions(numberQuestions)).rejects.toThrow("Mock - Error fetching Questions");
 
     })
-
 
     it("should return an error if calling wikidata fails", async () => {
 
@@ -166,113 +123,89 @@ describe("Question Service - Question Generator", () => {
 
     it("should return 1 image question with all correct parameters when generator succeeds", async () => {
 
-        // Mock response for fetching MongoDB documents
-        const mockResponseAggregate: object[] = [{
-            questionTemplate: 'This flag is from...?',
-            question_type: {
-                name: 'Images_Flags',
-                query: `SELECT ?templateLabel ?answerLabel
-              WHERE {
-                ?answer wdt:P31 wd:$$$; # Entity
-                        wdt:P41 ?template.  # Capital
-                SERVICE wikibase:label { bd:serviceParam wikibase:language "en"}
-              }
-              ORDER BY UUID() # Add randomness to the results
-              LIMIT 5
-              `,
-                entities: [
-                    'Q6256', // Country (any)
-                    'Q10742', // Autonomous Community of Spain
-                    'Q35657' // State of the United States],
-                ]
-            },
-        }];
-        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+        const response = await mockQuestionGenerationWithImage();
 
-        // Mock response for Wikidata call
-        const mockResponseWikidata = [{
-            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Lesotho.svg",
-            answerLabel: "Lesotho"
-        }, {
-            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Senegal.svg",
-            answerLabel: "Senegal"
-        }, {
-            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Zambia.svg",
-            answerLabel: "Zambia"
-        }, {
-            templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
-            answerLabel: "Slovak Republic"
-        }];
-        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+        checkCalltoQuestionModelAggregate();
 
-        const response = await generateQuestions(numberQuestions) as any
-
-        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
-            { $sample: { size: numberQuestions } },
-        ]);
-
-        expect(response[0]).toHaveProperty("id") // a given id
-        expect(response[0]).toHaveProperty("question") // the generated question
-        expect(response[0]).toHaveProperty("answers") // a list of answers
-        expect(response[0]).toHaveProperty("image") // an image field
-        expect(response[0].answers.length).toBe(4) // 4 answers
-        expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+        checkAllFieldsWithImage(response);
     })
 
     it("should return 1 question with all correct parameters and no image field when not needed", async () => {
 
-        // Mock response for fetching MongoDB documents
-        const mockResponseAggregate: object[] = [{
-            questionTemplate: 'What is the Capital of $$$ ?',
-            question_type: {
-                name: 'Capitals',
-                query: `SELECT ?templateLabel ?answerLabel
-                        WHERE {
-                        ?template wdt:P31 wd:$$$; # Entity
-                        wdt:P36 ?answer.  # Capital
-                        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es"}
-                        }
-                        ORDER BY UUID() # Add randomness to the results
-                        LIMIT 10`,
-                entities: [
-                    'Q6256',
-                    'Q10742',
-                ],
-            }
-        }];
-        (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+        const response = await mockQuestionGeneration();
 
-        // Mock response for Wikidata call
-        const mockResponseWikidata = [{
-            templateLabel: "Peru",
-            answerLabel: "Lima"
-        }, {
-            templateLabel: "Spain",
-            answerLabel: "Madrid"
-        }, {
-            templateLabel: "Russia",
-            answerLabel: "Moscow"
-        }, {
-            templateLabel: "Ucrania",
-            answerLabel: "Kiev"
-        }];
-        (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+        checkCalltoQuestionModelAggregate();
 
-        const response = await generateQuestions(numberQuestions) as any
-
-        expect(QuestionModel.aggregate).toHaveBeenCalledWith([
-            { $sample: { size: numberQuestions } },
-        ]);
-
-        expect(response[0]).toHaveProperty("id") // a given id
-        expect(response[0]).toHaveProperty("question") // the generated question
-        expect(response[0]).toHaveProperty("answers") // a list of answers
-        expect(response[0].answers.length).toBe(4) // 4 answers
-        expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
-        expect(response[0]).not.toHaveProperty("image") // no image field
+        checkAllFieldsWithoutImage(response);
     })
-
-
-
-
 })
+
+function checkCalltoQuestionModelAggregate() {
+    expect(QuestionModel.aggregate).toHaveBeenCalledWith([
+        { $sample: { size: numberQuestions } },
+    ]);
+}
+
+async function mockQuestionGenerationWithImage() {
+    // Mock response for fetching MongoDB documents
+    const mockResponseAggregate: object[] = [{
+        questionTemplate: 'This flag is from...?',
+        question_type: {
+            name: 'Images_Flags',
+            query: `SELECT ?templateLabel ?answerLabel
+          WHERE {
+            ?answer wdt:P31 wd:$$$; # Entity
+                    wdt:P41 ?template.  # Capital
+            SERVICE wikibase:label { bd:serviceParam wikibase:language "en"}
+          }
+          ORDER BY UUID() # Add randomness to the results
+          LIMIT 5
+          `,
+            entities: [
+                'Q6256', // Country (any)
+                'Q10742', // Autonomous Community of Spain
+                'Q35657' // State of the United States],
+            ]
+        },
+    }];
+    (QuestionModel.aggregate as jest.Mock).mockReturnValue(mockResponseAggregate)
+
+    // Mock response for Wikidata call
+    const mockResponseWikidata = [{
+        templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Lesotho.svg",
+        answerLabel: "Lesotho"
+    }, {
+        templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Senegal.svg",
+        answerLabel: "Senegal"
+    }, {
+        templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Zambia.svg",
+        answerLabel: "Zambia"
+    }, {
+        templateLabel: "https://commons.wikimedia.org/wiki/Special:FilePath/Flag%20of%20Slovakia%20%281939%E2%80%931945%29.svg",
+        answerLabel: "Slovak Republic"
+    }];
+    (getWikidataSparql as jest.Mock).mockReturnValue(mockResponseWikidata)
+
+    const response = await generateQuestions(numberQuestions) as any
+    return response;
+
+}
+
+function checkAllFields(response: any) {
+    expect(response[0]).toHaveProperty("id") // a given id
+    expect(response[0]).toHaveProperty("question") // the generated question
+    expect(response[0]).toHaveProperty("answers") // a list of answers
+    expect(response[0].answers.length).toBe(4) // 4 answers
+    expect(response[0]).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+}
+
+function checkAllFieldsWithImage(response: any) {
+    checkAllFields(response)
+    expect(response[0]).toHaveProperty("image") // an image field
+}
+
+function checkAllFieldsWithoutImage(response: any) {
+    checkAllFields(response)
+    expect(response[0]).not.toHaveProperty("image") // no image field
+}
+


### PR DESCRIPTION
I have added questions that include the url of an image that is needed to answer them.
For now, the questions generated may or may not contain this field, depending if they are based on images or not. In the future we may want to modify our endpoint so it's possible to request  questions not including or only including images.
I also made some changes to the question generator to support the new templates added (3 templates for image based questions).