### PR TITLE
Added Question Types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - run: npm --prefix users/userservice test -- --coverage
     - run: npm --prefix questionservice test -- --coverage
     - run: npm --prefix gatewayservice test -- --coverage
-    # - run: npm --prefix webapp test -- --coverage
+    - run: npm --prefix webapp test -- --coverage
     - name: Analyze with SonarCloud
       uses: sonarsource/sonarcloud-github-action@master
       env:
@@ -49,4 +49,4 @@ jobs:
     - run: npm --prefix questionservice install
     - run: npm --prefix webapp run build
     - run: sudo setcap 'cap_net_bind_service=+ep' `which node`
-    # - run: npm --prefix webapp run test:e2eci
+    - run: npm --prefix webapp run test:e2eci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - run: npm --prefix users/userservice test -- --coverage
     - run: npm --prefix questionservice test -- --coverage
     - run: npm --prefix gatewayservice test -- --coverage
-    - run: npm --prefix webapp test -- --coverage
+    # - run: npm --prefix webapp test -- --coverage
     - name: Analyze with SonarCloud
       uses: sonarsource/sonarcloud-github-action@master
       env:
@@ -49,4 +49,4 @@ jobs:
     - run: npm --prefix questionservice install
     - run: npm --prefix webapp run build
     - run: sudo setcap 'cap_net_bind_service=+ep' `which node`
-    - run: npm --prefix webapp run test:e2eci
+    # - run: npm --prefix webapp run test:e2eci

--- a/gatewayservice/openapi.yaml
+++ b/gatewayservice/openapi.yaml
@@ -51,6 +51,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/questionLanguage'
         - $ref: '#/components/parameters/questionSize'
+        - $ref: '#/components/parameters/questionType'
       responses:
         200:
           description: Service has generated the requested number of questions. It is possible that not ALL questions requested are generated due to timeouts for Wikidata API.
@@ -74,6 +75,7 @@ paths:
                         - id: 4
                           text: 1945
                       correctAnswerId: 1
+                      type: 'history'
                 - questionImage:
                   summary: A question, an Image URL and 4 possible answers have been generated.
                   value:
@@ -89,6 +91,7 @@ paths:
                         - id: 4
                           text: France
                       correctAnswerId: 1
+                      type: 'geography'
                       image: 'https://upload.wikimedia.org/wikipedia/commons/a/ab/img_name.ext'  
 
         400:
@@ -128,6 +131,12 @@ paths:
                     status: Fail
                     data:
                       error: The provided language is not supported     
+                typeNotSupported:
+                  summary: Client has provided a type not supported for question generation.
+                  value:
+                    status: Fail
+                    data:
+                      error: The provided type *** is not supported
         500:
           description: An internal server error has occured. Either DB related, Wikidata API or others.
           content:
@@ -150,6 +159,38 @@ paths:
                   value:
                     status: fail
                     message: Can't generate questions! Error while fetching Wikidata
+  /questions/types:
+    get:
+      summary: Gets the types of questions that can be generated.
+      tags:
+        - Question Service
+      operationId: getQuestionTypes
+      responses:
+        200:
+            description: Service returns the types of questions that can be generated.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/QuestionTypes'
+                examples:
+                  - types:
+                    summary: A list wirh all possible types.
+                    value:
+                    - types: ['history', 'geography', 'art', 'science', 'sports', 'entertainment', 'other']
+                    - n_types: 7
+        500:
+            description: An internal server error has occured.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ServerErrorQSResponse'
+                examples:
+                  - dbError:
+                    summary: Error when trying to ontain types.
+                    value:
+                      status: fail
+                      message: There was a problem obtaining types, please try again later.
+            
 
   /history:
 
@@ -290,7 +331,19 @@ components:
       description: An array with n generated questions
       items:
         $ref: '#/components/schemas/QuestionJson'
-      
+
+    QuestionTypes:
+      type: object
+      properties:
+        types:
+          type: array
+          description: An array with all possible types of questions
+          items:
+            type: string
+        n_types:
+          type: integer
+          description: The number of types of questions available 
+
     QuestionJson:
       type: object
       properties:
@@ -315,6 +368,9 @@ components:
         correctAnswerId:
           type: string
           description: The identifier of the correct answer.
+        type:
+          type: string
+          description: The type of the question generated
         image:
           type: string
           description: A URL of an image that describes the question.
@@ -424,6 +480,18 @@ components:
         size-example:
           summary: Retrieving 5 random questions.
           value: 5
+    
+    questionType:
+      name: type
+      in: query
+      description: Type of questions to be generated.
+      required: false
+      schema:
+        type: string
+      examples:
+        type-example:
+          summary: Retrieving questions related to history.
+          value: history
     
     questionLanguage:
       name: lang

--- a/gatewayservice/src/controllers/question-controller.ts
+++ b/gatewayservice/src/controllers/question-controller.ts
@@ -19,4 +19,19 @@ const getQuestions = async (
   }
 };
 
-export { getQuestions };
+const getQuestionTypes = async (
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const questionTypesResponse = await axios.get(
+      QUESTION_SERVICE_URL + '/question/types'
+    );
+
+    res.json(questionTypesResponse.data);
+  } catch (error: any) {
+    next(error);
+  }
+}
+
+export { getQuestions, getQuestionTypes };

--- a/gatewayservice/src/controllers/question-controller.ts
+++ b/gatewayservice/src/controllers/question-controller.ts
@@ -20,12 +20,13 @@ const getQuestions = async (
 };
 
 const getQuestionTypes = async (
+  _: Request,
   res: Response,
   next: NextFunction
 ) => {
   try {
     const questionTypesResponse = await axios.get(
-      QUESTION_SERVICE_URL + '/question/types'
+      QUESTION_SERVICE_URL + '/questions/types'
     );
 
     res.json(questionTypesResponse.data);

--- a/gatewayservice/src/routes/question-routes.ts
+++ b/gatewayservice/src/routes/question-routes.ts
@@ -1,8 +1,8 @@
 import express from 'express';
-import { getQuestions } from '../controllers/question-controller';
+import { getQuestions, getQuestionTypes } from '../controllers/question-controller';
 
 const router = express.Router();
-
+router.get('/questions/types', getQuestionTypes);
 router.get('/questions', getQuestions);
 
 export default router;

--- a/gatewayservice/test/gateway-service.test.ts
+++ b/gatewayservice/test/gateway-service.test.ts
@@ -1,5 +1,5 @@
 const request = require('supertest');
-import axios, {AxiosError, AxiosHeaders, AxiosResponse} from 'axios';
+import axios, { AxiosError, AxiosHeaders, AxiosResponse } from 'axios';
 import app from '../src/app';
 import { Response } from 'express';
 
@@ -8,14 +8,18 @@ jest.mock('axios');
 const getMocks = (url: string) => {
   if (url.endsWith('/questions')) {
     return Promise.resolve({ data: { size: 10 } });
-  } else if (url.endsWith('/history')) {
+  }
+  else if (url.endsWith('/questions/types')) {
+    return Promise.resolve({ data: { types: {} } });
+  }
+  else if (url.endsWith('/history')) {
     return Promise.resolve({ data: { gamesPlayed: 10 } });
   } else if (url.endsWith('/history/leaderboard')) {
-    return Promise.resolve({ data: { leaderboard:  {} } });
+    return Promise.resolve({ data: { leaderboard: {} } });
   } else if (url.endsWith('/health')) {
     return Promise.resolve();
   } else if (url.endsWith('/profile')) {
-    return Promise.resolve({data: { bio: 'Test' }});
+    return Promise.resolve({ data: { bio: 'Test' } });
   }
   return Promise.resolve({});
 };
@@ -30,7 +34,7 @@ const postMocks = (url: string) => {
   } else if (url.endsWith('/history/increment')) {
     return Promise.resolve({ data: { gamesPlayed: 20 } });
   } else if (url.endsWith('/profile')) {
-    return Promise.resolve({data: { bio: 'Test' }});
+    return Promise.resolve({ data: { bio: 'Test' } });
   }
   return Promise.resolve({});
 };
@@ -53,8 +57,8 @@ describe('Gateway Service', () => {
   it('should get an error when auth service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .post('/login')
-          .send({ username: 'testuser', password: 'testpassword' })
+        .post('/login')
+        .send({ username: 'testuser', password: 'testpassword' })
     });
 
     expect(response.statusCode).toBe(500);
@@ -74,8 +78,8 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .post('/adduser')
-          .send({ username: 'newuser', password: 'newpassword' })
+        .post('/adduser')
+        .send({ username: 'newuser', password: 'newpassword' })
     });
 
     expect(response.statusCode).toBe(500);
@@ -95,8 +99,8 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .post('/history')
-          .send({ username: 'testuser', gamesPlayed: 10 })
+        .post('/history')
+        .send({ username: 'testuser', gamesPlayed: 10 })
     });
 
     expect(response.statusCode).toBe(500);
@@ -105,8 +109,8 @@ describe('Gateway Service', () => {
   // Test POST /history/increment endpoint
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .post('/history/increment')
-        .send({ username: 'testuser', gamesPlayed: 10 });
+      .post('/history/increment')
+      .send({ username: 'testuser', gamesPlayed: 10 });
 
     expect(response.statusCode).toBe(200);
     expect(response.body.gamesPlayed).toBe(20);
@@ -116,8 +120,8 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .post('/history/increment')
-          .send({ username: 'testuser', gamesPlayed: 10 })
+        .post('/history/increment')
+        .send({ username: 'testuser', gamesPlayed: 10 })
     });
 
     expect(response.statusCode).toBe(500);
@@ -138,9 +142,9 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .get('/history')
-          .query({ user: 'newuser' })
-          .send();
+        .get('/history')
+        .query({ user: 'newuser' })
+        .send();
     });
 
     expect(response.statusCode).toBe(500);
@@ -149,8 +153,8 @@ describe('Gateway Service', () => {
   // Test GET /history/leaderboard endpoint
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .get('/history/leaderboard')
-        .send();
+      .get('/history/leaderboard')
+      .send();
 
     expect(response.statusCode).toBe(200);
     expect(response.body.leaderboard).toBeDefined();
@@ -160,8 +164,8 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .get('/history/leaderboard')
-          .send();
+        .get('/history/leaderboard')
+        .send();
     });
 
     expect(response.statusCode).toBe(500);
@@ -182,9 +186,30 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .get('/questions')
-          .query({ size: 10 })
-          .send();
+        .get('/questions')
+        .query({ size: 10 })
+        .send();
+    });
+
+    expect(response.statusCode).toBe(500);
+  });
+
+  // Test /questions/types endpoint
+  it('should forward question types request to question service', async () => {
+    const response = await request(app)
+      .get('/questions/types')
+      .send();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.types).toBeDefined();
+  });
+
+  // Test /questions/types endpoint down
+  it('should get an error when question service is down', async () => {
+    const response = await testWithoutServices(() => {
+      return request(app)
+        .get('/questions/types')
+        .send();
     });
 
     expect(response.statusCode).toBe(500);
@@ -278,8 +303,8 @@ describe('Gateway Service', () => {
   // Test POST /history endpoint with authorization header
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .post('/history')
-        .set('authorization', '');
+      .post('/history')
+      .set('authorization', '');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.gamesPlayed).toBe(10);
@@ -288,7 +313,7 @@ describe('Gateway Service', () => {
   // Test POST /history endpoint with headers
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .post('/history');
+      .post('/history');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.gamesPlayed).toBe(10);
@@ -297,8 +322,8 @@ describe('Gateway Service', () => {
   // Test POST /history endpoint with authorization header
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .post('/history')
-        .set('authorization', '');
+      .post('/history')
+      .set('authorization', '');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.gamesPlayed).toBe(10);
@@ -307,8 +332,8 @@ describe('Gateway Service', () => {
   // Test POST /history/increment endpoint with authorization header
   it('should forward history request to user service', async () => {
     const response = await request(app)
-        .post('/history/increment')
-        .set('authorization', '');
+      .post('/history/increment')
+      .set('authorization', '');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.gamesPlayed).toBe(20);
@@ -328,8 +353,8 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .post('/profile')
-          .send({ username: 'testuser', bio: 'Test' })
+        .post('/profile')
+        .send({ username: 'testuser', bio: 'Test' })
     });
 
     expect(response.statusCode).toBe(500);
@@ -350,16 +375,16 @@ describe('Gateway Service', () => {
   it('should get an error when user service is down', async () => {
     const response = await testWithoutServices(() => {
       return request(app)
-          .get('/profile')
-          .query({ user: 'newuser' })
-          .send();
+        .get('/profile')
+        .query({ user: 'newuser' })
+        .send();
     });
 
     expect(response.statusCode).toBe(500);
   });
 });
 
-async function testWithoutServices(paramFunc : Function) {
+async function testWithoutServices(paramFunc: Function) {
   // Clear the mocks
   (axios.get as jest.Mock).mockImplementation((url: string) => { if (url) return; })
   await (axios.post as jest.Mock).mockImplementation((url: string) => { if (url) return; })

--- a/questionservice/src/controllers/question-controller.ts
+++ b/questionservice/src/controllers/question-controller.ts
@@ -1,23 +1,36 @@
 import { Request, Response } from 'express';
 import { generateQuestions } from '../services/question-generator';
-import { validateLanguage, validateNumber, validateSizePresent } from '../utils/validations';
+import { validateLanguage, validateNumber, validateSizePresent, validateTypes } from '../utils/validations';
+import { getQuestionTypes } from '../services/question-storage';
+
 
 const generateQuestionsController = async (req: Request, res: Response) => {
   try {
     const requestedParam = req.query.size;
     const language = req.query.lang;
+    let types = req.query.type;
+
 
     validateSizePresent(req);
-    
+
     // If language is not present, there is no need to validate since undefined values are accepted
     if (language) {
-        validateLanguage(language as string)
+      validateLanguage(language as string)
     }
+    // If types is not present, there is no need to validate since undefined values are accepted
+    if (types) {
+      if (typeof types === 'string') {
+        types = [types];
+      }
+      types = types as string[];
+      types.map((type) => type.toLowerCase());
 
+      await validateTypes(types)
+    }
     let size = validateNumber(requestedParam as string);
 
     try {
-      const questions = await generateQuestions(size, language);
+      const questions = await generateQuestions(size, language, types);
       res.json(questions);
     } catch (err: any) {
       res.status(500).json({
@@ -30,4 +43,14 @@ const generateQuestionsController = async (req: Request, res: Response) => {
   }
 };
 
-export { generateQuestionsController };
+const getQuestionTypesController = async (_: Request, res: Response) => {
+  try {
+    let types = await getQuestionTypes();
+    res.status(200).json({ types: types, n_types: types.length });
+  } catch (error: any) {
+    console.log(error);
+    res.status(500).json({ status: 'fail', message: 'There was a problem obtaining types, please try again later.' });
+  }
+}
+
+export { generateQuestionsController, getQuestionTypesController };

--- a/questionservice/src/models/question-model.ts
+++ b/questionservice/src/models/question-model.ts
@@ -6,6 +6,7 @@ const questionSchema = new Schema<Question>({
     question: { type: String, required: true },
     answers: { type: [Object], required: true },
     correctAnswerId: { type: Number, required: true },
+    type: { type: String, required: true },
     image: { type: String, required: false }
 });
 

--- a/questionservice/src/models/template-model.ts
+++ b/questionservice/src/models/template-model.ts
@@ -8,12 +8,14 @@ interface QuestionType {
   name: string;
   query: string;
   entities: string[];
+  typeName: string;
 }
 
 const questionTypeSchema = new Schema<QuestionType>({
   name: { type: String, required: true },
   query: { type: String, required: true },
   entities: { type: [String], required: false },
+  typeName: { type: String, required: true },
 });
 
 interface Question {
@@ -54,6 +56,7 @@ const generateSampleTest = () => {
         'Q6256', // Country (any)
         'Q10742', // Autonomous Community of Spain
       ],
+      typeName: 'geography',
     },
   });
 
@@ -75,7 +78,8 @@ const generateSampleTest = () => {
         'Q6256', // Country (any)
         'Q10742', // Autonomous Community of Spain
         'Q35657', // State of the United States
-      ], // City
+      ],
+      typeName: 'geography',
     },
   });
 
@@ -100,7 +104,8 @@ const generateSampleTest = () => {
         'Q6256', // Country (any)
         'Q10742', // Autonomous Community of Spain
         'Q35657', // State of the United States
-      ], // City
+      ],
+      typeName: 'history',
     },
   });
 
@@ -121,10 +126,9 @@ const generateSampleTest = () => {
           LIMIT 10
           `,
       entities: [
-        'Q198', // War
+        'Q198' // War
       ],
-
-      // , "Q209715"] // Coronation of a king/queen
+      typeName: 'history',
     },
   });
 
@@ -147,6 +151,7 @@ const generateSampleTest = () => {
         LIMIT 10
         `,
       entities: [],
+      typeName: 'science',
     },
   });
 
@@ -168,6 +173,7 @@ const generateSampleTest = () => {
       LIMIT 10
       `,
       entities: [],
+      typeName: 'science',
     },
   });
 
@@ -191,7 +197,8 @@ const generateSampleTest = () => {
         'Q6256', // Country (any)
         'Q10742', // Autonomous Community of Spain
         'Q35657' // State of the United States],
-      ]
+      ],
+      typeName: 'geography',
     },
   });
 
@@ -211,7 +218,8 @@ const generateSampleTest = () => {
       }
       LIMIT 5    
       `,
-      entities: []
+      entities: [],
+      typeName: 'science',
     },
   });
 
@@ -230,7 +238,8 @@ const generateSampleTest = () => {
       }
       LIMIT 5  
       `,
-      entities: []
+      entities: [],
+      typeName: 'science',
     },
   });
 };

--- a/questionservice/src/routes/question-routes.ts
+++ b/questionservice/src/routes/question-routes.ts
@@ -1,22 +1,24 @@
 import express from 'express';
-import { generateQuestionsController } from '../controllers/question-controller';
+import { generateQuestionsController, getQuestionTypesController } from '../controllers/question-controller';
 
 const router = express.Router();
 
 router.get('/questions', generateQuestionsController);
 
+router.get('/questions/types', getQuestionTypesController);
+
 // Default endpoint
-router.get('/*', (_req,res) =>{
-    
+router.get('/*', (_req, res) => {
+
     res.status(200).json({
-        status:"success",
-        data:{
+        status: "success",
+        data: {
             serviceName: "Question Service",
             health: "Operative",
             greet: "Hello! I think you are trying to connect to the Question Service. Pls," +
-            "access through other endpoint like /questions?size=10"
+                "access through other endpoint like /questions?size=10"
         }
-        
+
     });
 });
 

--- a/questionservice/src/services/question-generator.ts
+++ b/questionservice/src/services/question-generator.ts
@@ -25,18 +25,23 @@ const SPARQL_TIMEOUT = 5000; // 5000 ms = 5s
  */
 async function generateQuestions(
   size: number,
-  lang: any
+  lang: any,
+  types: any = []
 ): Promise<object[] | void> {
-  let numberQuestionsDB = Math.min(Math.floor(size / 2), await QuestionModel.countDocuments());
-  let questionsToGenerate = size - numberQuestionsDB;
   console.log('------------------');
   console.log('Questions requested: ' + size);
+  if (types) {
+    console.log('------------------');
+    console.log("Requested questions of Type: " + types)
+  }
+  let numberQuestionsDB = await getNumberQuestionsDB(types, size);
+  let questionsToGenerate = size - numberQuestionsDB;
   console.log('------------------');
   console.log('Questions from DB: ' + numberQuestionsDB);
   console.log('Expected Questions to Generate: ' + questionsToGenerate);
 
   // Trying to obtain n random documents
-  let randomQuestionsTemplates = await getRandomQuestions(questionsToGenerate);
+  let randomQuestionsTemplates = await getRandomQuestions(questionsToGenerate, types);
 
   // Generate and return questions generated from those documents
   let questionsArray = await generateQuestionsArray(randomQuestionsTemplates);
@@ -46,7 +51,7 @@ async function generateQuestions(
 
   // We take the remaining questions from DB
   numberQuestionsDB = size - questionsArray.length;
-  let questionsArrayDB = await getQuestionsFromDB(numberQuestionsDB);
+  let questionsArrayDB = await getQuestionsFromDB(numberQuestionsDB, types);
   // Save questions to DB
   saveQuestions(questionsArray);
 
@@ -59,6 +64,13 @@ async function generateQuestions(
 
   // Translation and number validation
   return await prepareQuestionsForLanguage(questionsArray, lang);
+}
+
+async function getNumberQuestionsDB(types: any, size: number): Promise<number> {
+  if (types.length == 0)
+    return Math.min(Math.floor(size / 2), await QuestionModel.countDocuments());
+  else
+    return Math.min(Math.floor(size / 2), await QuestionModel.countDocuments({ 'type': { $in: types } }));
 }
 
 /**
@@ -89,14 +101,18 @@ function performChecks(questionsArray: any[], lang: string = 'en') {
  * @param questionsDB number of questions to get from DB
  * @returns array containing questions in JSON format
  */
-const getQuestionsFromDB = async (questionsDB: number) => {
-  let questionsArrayDB = await QuestionModel.aggregate([
+const getQuestionsFromDB = async (questionsDB: number, types: any) => {
+  let questionsArrayDB: any[] = [];
+  if (types.length == 0)
+    questionsArrayDB = await QuestionModel.aggregate([{ $sample: { size: questionsDB } }]);
+  else
+    questionsArrayDB = await QuestionModel.aggregate([{ $match: { 'type': { $in: types } } },
     { $sample: { size: questionsDB } },
-  ]);
+    ]);
 
   questionsArrayDB = questionsArrayDB.map((q: any) => {
-    if (q.image === undefined) return questionJsonBuilder(q.question, q.answers);
-    return questionJsonBuilder(q.question, q.answers, q.image);
+    if (q.image === undefined) return questionJsonBuilder(q.question, q.answers, q.type);
+    return questionJsonBuilder(q.question, q.answers, q.type, q.image);
   });
   console.log('------------------');
   console.log('Retrieved ' + questionsArrayDB.length + ' Questions from DB');
@@ -139,21 +155,20 @@ const translateQuestionsArray = async (
     // Causes unexpected behaviour due to loops and awaits (concurrency) 
     // If query was size = 9, it was adding 5 + 4 + 3 + 2 + 1 instead of 5 + 4)
     additionalQuestions = await ... 
-
+ 
     // Appart from that, this part was adding directly the arrays: 
     // randomQuestions = [t1, t2, t3, t4, t5, [t6, t7, t8, t9], [t10, t11, t12], ...]
     randomQuestions.push(additional Questions)
     ...
   }
-
+ 
   In conclusion, careful with loops and concurrency issues. Also, have in mind
   this curious feature of "..." for pushing arrays
 */
-async function getRandomQuestions(n: number): Promise<any[]> {
+async function getRandomQuestions(n: number, types: any): Promise<any[]> {
   // We try to obtain the whole random templates
-  let randomQuestionsTemplates = await TemplateModel.aggregate([
-    { $sample: { size: n } },
-  ]);
+  let randomQuestionsTemplates = await aggregateQuestionTemplates(n, types);
+
   async function addMoreRandomQuestionsIfNeeded(): Promise<any[]> {
     // If required questions are fulfilled, simply returning the questions
     if (randomQuestionsTemplates.length >= n) return randomQuestionsTemplates;
@@ -162,9 +177,7 @@ async function getRandomQuestions(n: number): Promise<any[]> {
     const remaining = n - randomQuestionsTemplates.length;
 
     // Fetch again from DB more templates
-    const additionalQuestions = await TemplateModel.aggregate([
-      { $sample: { size: remaining } },
-    ]);
+    let additionalQuestions = await aggregateQuestionTemplates(remaining, types);
     // ... additionalQuestions -> this is called "sparse" syntax
     // is used to concatenate the elements of array individually and not the whole array
     // otherwise, the result would be:
@@ -176,6 +189,18 @@ async function getRandomQuestions(n: number): Promise<any[]> {
 
   // call function that add more if needed
   return addMoreRandomQuestionsIfNeeded();
+}
+
+
+async function aggregateQuestionTemplates(n: number, types: any): Promise<any[]> {
+  if (types.length == 0)
+    return await TemplateModel.aggregate([
+      { $sample: { size: n } },
+    ]);
+  return await TemplateModel.aggregate([{ $match: { 'question_type.typeName': { $in: types } } },
+  { $sample: { size: n } },
+  ]);
+
 }
 
 /**
@@ -256,9 +281,10 @@ const generateQuestionJson = async (
       return questionJsonBuilder(
         questionGen,
         answersArray,
+        questionTemplate.question_type.typeName,
         image
       );
-    else return questionJsonBuilder(questionGen, answersArray);
+    else return questionJsonBuilder(questionGen, answersArray, questionTemplate.question_type.typeName);
   } catch (error) {
     throw new Error('Error while fetching Wikidata');
   }
@@ -275,12 +301,14 @@ const generateQuestionJson = async (
 const questionJsonBuilder = (
   questionGen: string,
   answersArray: object[],
+  type: string,
   image: string = '',
 ): object => {
   const myJson: Question = {
     question: questionGen,
     answers: answersArray,
     correctAnswerId: 1,
+    type: type,
   };
 
   if (image != '') {

--- a/questionservice/src/services/question-storage.ts
+++ b/questionservice/src/services/question-storage.ts
@@ -1,4 +1,5 @@
 import { QuestionModel } from '../models/question-model';
+import { TemplateModel } from '../models/template-model';
 /**
  * Stores the questions in the database.
  * If these questions are already on the database, they won't stored.
@@ -45,4 +46,11 @@ const saveUniqueQuestionNoImage = async (question: any) => {
         QuestionModel.create(question);
 }
 
-export { saveQuestions }
+
+const getQuestionTypes = async () => {
+    let types = await TemplateModel.distinct('question_type.typeName');
+    types = types.map((type: any) => type.toLowerCase());
+    return types;
+}
+
+export { saveQuestions, getQuestionTypes }

--- a/questionservice/src/utils/question-generator-utils.ts
+++ b/questionservice/src/utils/question-generator-utils.ts
@@ -7,6 +7,7 @@ interface Question {
     question: string,
     answers: object[],
     correctAnswerId: number,
+    type: string,
     image?: string
 }
 

--- a/questionservice/src/utils/validations.ts
+++ b/questionservice/src/utils/validations.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import { getQuestionTypes } from '../services/question-storage';
 
 /**
  * Validates if the size parameter is present in the request
@@ -33,6 +34,20 @@ function validateNumber(field: string) {
   }
 
   return size;
+}
+
+/**
+ * Validates if the types field is accepted
+ * @param types Array of types to be validated
+ */
+async function validateTypes(types: string[]) {
+  const acceptedTypes = await getQuestionTypes();
+
+  for (let questionType of types) {
+    if (!acceptedTypes.includes(questionType.toLowerCase())) {
+      throw new Error('The provided type ' + questionType + ' is not supported');
+    }
+  }
 }
 
 /**
@@ -187,4 +202,4 @@ function validateLanguage(field: string) {
   }
 }
 
-export { validateNumber, validateSizePresent, validateLanguage };
+export { validateNumber, validateSizePresent, validateLanguage, validateTypes };

--- a/questionservice/test/question-generator.test.ts
+++ b/questionservice/test/question-generator.test.ts
@@ -104,6 +104,25 @@ describe("Question Service - Question Generator", () => {
         checkAllFields(response);
     })
 
+    it("should return 2 questions with all correct parameters given a type", async () => {
+
+        // Setting up the mocks
+        const numberQuestions = 2;
+        await mocktemplateModelAggregate(numberQuestions);
+        await mockWikidataSparql(numberQuestions)
+        await mockQuestionAggregate();
+        await mockQuestionCount();
+
+        // Testing function
+        const response = await generateQuestions(numberQuestions, "en", ['geography']) as any;
+
+        // It must be generated two questions
+        expect(response.length).toBe(numberQuestions)
+        checkAllFields(response);
+    })
+
+
+
     it("should return an error if fetching documents from Mongo fails - First call", async () => {
         await mockQuestionCount();
 
@@ -308,6 +327,7 @@ async function mocktemplateModelAggregate(numberReturnValues: number) {
                 'Q6256',
                 'Q10742',
             ],
+            typeName: 'geography',
         }
     }];
 
@@ -340,7 +360,9 @@ async function mockTemplateModelAggregateWithImage() {
                 'Q6256', // Country (any)
                 'Q10742', // Autonomous Community of Spain
                 'Q35657' // State of the United States],
-            ]
+            ],
+            typeName: 'geography',
+
         },
     }];
 
@@ -380,6 +402,7 @@ function checkAllFields(response: any) {
         expect(r).toHaveProperty("answers") // a list of answers
         expect(r.answers.length).toBe(4) // 4 answers
         expect(r).toHaveProperty("correctAnswerId", 1) // a correct answer Id set to 1
+        expect(r).toHaveProperty("type") // a type field
     }
 
 }

--- a/questionservice/test/question-service.test.ts
+++ b/questionservice/test/question-service.test.ts
@@ -98,7 +98,7 @@ describe("Question Service - Question Generation", () => {
         await generateQuestionsController(req, res)
 
         // Ensuring mock fn was called like => await generateQuestions(3)
-        expect(generateQuestions).toHaveBeenCalledWith(mockResponse.length, "en");
+        expect(generateQuestions).toHaveBeenCalledWith(mockResponse.length, "en", undefined);
         // Ensuring mock fn was called like => res.json(['Question1', 'Question2', 'Question3'])
         expect(res.json).toHaveBeenCalledWith(mockResponse)
 
@@ -120,7 +120,7 @@ describe("Question Service - Question Generation", () => {
         await generateQuestionsController(req, res)
 
         // Ensuring mock fn was called like => await generateQuestions(3)
-        expect(generateQuestions).toHaveBeenCalledWith(3, "en");
+        expect(generateQuestions).toHaveBeenCalledWith(3, "en", undefined);
         // Ensuring mock fn was called like => res.status(500)
         expect(res.status).toHaveBeenCalledWith(500)
         // Ensuring mock fn was called like => res.json({status: 'fail'})


### PR DESCRIPTION
Now it's possible to provide a type attribute on the /questions endpoint, so it'll only return questions of that type.
I also added a new endpoint that when called returns a list of all the possible types.